### PR TITLE
Update ticket allocation test to utilise jsonapi spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ A 4xx status code must be returned on any request that attempts to purchase more
             "title": "Unable to purchase provided quantity",
             "detail": "Unable to reserve given quantity of ticket options",
             "source": {
-                "pointer": "/data/quantity"
+                "pointer": "/data/attributes/quantity"
             }
         }
     ]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For reference, here at Fatsoma we primarily develop using ruby on rails and
 golang. However feel free to solve this in whatever language you feel comfortable with and use a framework if desired.
 
 We are mainly looking for clean, well architected, tested code that highlights
-your skillset and shows technical proficiency.
+your skill set and shows technical proficiency.
 
 ### Database
 
@@ -35,7 +35,7 @@ this problem.
 ## Problem definition
 
 The following three routes need to be built to enable allocating of ticket
-options to multiple purchases.
+options to multiple purchases. They all correspond to the jsonapi spec (https://jsonapi.org/)
 
 The solution needs to ensure that the allocation does not drop below 0,
 and the purchased amounts are not greater than the allocation given.
@@ -58,9 +58,14 @@ Request Body:
 
 ```json
 {
-  "name": "example",
-  "desc": "sample description",
-  "allocation": 100
+    "data": {
+        "type": "ticket_options",
+        "attributes": {
+            "name": "example",
+            "description": "sample description",
+            "allocation": 100
+        }
+    }
 }
 ```
 
@@ -68,10 +73,15 @@ Response Body:
 
 ```json
 {
-  "id": "70b751fe-04dd-4dd1-8955-ab9b188ddb1f",
-  "name": "example",
-  "desc": "sample description",
-  "allocation": 100
+    "data": {
+        "type": "ticket_options",
+        "id": "70b751fe-04dd-4dd1-8955-ab9b188ddb1f",
+        "attributes": {
+            "name": "example",
+            "description": "sample description",
+            "allocation": 100
+        }
+    }
 }
 ```
 
@@ -87,10 +97,15 @@ Response Body:
 
 ```json
 {
-  "id": "70b751fe-04dd-4dd1-8955-ab9b188ddb1f",
-  "name": "example",
-  "desc": "sample description",
-  "allocation": 100
+    "data": {
+        "type": "ticket_options",
+        "id": "70b751fe-04dd-4dd1-8955-ab9b188ddb1f",
+        "attributes": {
+            "name": "example",
+            "description": "sample description",
+            "allocation": 100
+        }
+    }
 }
 ```
 
@@ -98,19 +113,80 @@ Response Body:
 
 Purchase a quantity of tickets from the allocation of the given ticket_option:
 
-`POST /ticket_options/:id/purchases`
+`POST /purchases`
 
 Request body:
 
 ```json
 {
-  "quantity": 2,
-  "user_id": "406c1d05-bbb2-4e94-b183-7d208c2692e1"
+    "data": {
+        "type": "purchases",
+        "attributes": {
+            "quantity": 2
+        },
+        "relationships": {
+            "ticket_option": {
+                "data": {
+                    "type": "ticket_options",
+                    "id": "969f4317-09f4-4b15-b8be-a87d40fb56fb"
+                }
+            },
+            "user": {
+                "data": {
+                    "type": "users",
+                    "id": "d6abe829-c28c-44ec-bee6-3183f2c53fef"
+                }
+            }
+        }
+    }
 }
+
 ```
 
-(No Response body)
+Response Body:
 
 A 2xx status code must be returned on success.
 
-A 4xx status code must be returned on any request that attempts to purchase more tickets than are available. In this case, no tickets should be purchased for that request.
+```json
+{
+    "data": {
+        "type": "purchases",
+        "id": "cd837712-fd86-4345-9e7f-d519c8db6c45",
+        "attributes": {
+            "quantity": 2
+        },
+        "relationships": {
+            "ticket_option": {
+                "data": {
+                    "type": "ticket_options",
+                    "id": "969f4317-09f4-4b15-b8be-a87d40fb56fb"
+                }
+            },
+            "user": {
+                "data": {
+                    "type": "users",
+                    "id": "d6abe829-c28c-44ec-bee6-3183f2c53fef"
+                }
+            }
+        }
+    }
+}
+```
+
+A 4xx status code must be returned on any request that attempts to purchase more tickets than are available. In this case, no tickets should be purchased for that request. Example error response given below
+
+```json
+{
+    "errors": [
+        {
+            "status": "400",
+            "code": "invalid_purchase_quantity",
+            "title": "Unable to purchase provided quantity",
+            "detail": "Unable to reserve given quantity of ticket options",
+            "source": {
+                "pointer": "/data/quantity"
+            }
+        }
+    ]
+}
+```

--- a/Ticket_Allocation.postman_collection.json
+++ b/Ticket_Allocation.postman_collection.json
@@ -1,17 +1,22 @@
 {
 	"info": {
+		"_postman_id": "a738e5c8-0312-4ed6-bf38-0943677f59f7",
 		"name": "Ticket Allocation",
-		"_postman_id": "c9337a0d-ac26-0331-634f-b7553c9f800c",
-		"description": "",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "164129"
 	},
 	"item": [
 		{
 			"name": "Get ticket option",
 			"request": {
 				"method": "GET",
-				"header": [],
-				"body": {},
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/vnd.api+json",
+						"type": "text"
+					}
+				],
 				"url": {
 					"raw": "localhost:3000/ticket_options/{{ticketOptionID}}",
 					"host": [
@@ -23,7 +28,7 @@
 						"{{ticketOptionID}}"
 					]
 				},
-				"description": "Get Ticket Option"
+				"description": "Get Ticket Option by provided Ticket Option ID"
 			},
 			"response": []
 		},
@@ -33,12 +38,13 @@
 				{
 					"listen": "test",
 					"script": {
-						"type": "text/javascript",
 						"exec": [
-							"var data = JSON.parse(responseBody);",
-							"postman.setEnvironmentVariable(\"ticketOptionID\", data[\"id\"]);",
+							"var data = JSON.parse(pm.response.text());",
+							"pm.environment.set(\"ticketOptionID\", data[\"data\"][\"id\"]);",
 							""
-						]
+						],
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -47,12 +53,12 @@
 				"header": [
 					{
 						"key": "Content-Type",
-						"value": "application/json"
+						"value": "application/vnd.api+json"
 					}
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"name\": \"Test ticket option\",\n    \"desc\": \"ticket opion description\",\n    \"allocation\": 100\n}"
+					"raw": "{\n    \"data\": {\n        \"type\": \"ticket_options\",\n        \"attributes\": {\n            \"name\": \"Test ticket option\",\n            \"description\": \"ticket option description\",\n            \"allocation\": 100\n        }\n    }\n}"
 				},
 				"url": {
 					"raw": "localhost:3000/ticket_options",
@@ -64,7 +70,7 @@
 						"ticket_options"
 					]
 				},
-				"description": "Create Ticket Option"
+				"description": "Create Ticket Option with given attributes"
 			},
 			"response": []
 		},
@@ -75,26 +81,24 @@
 				"header": [
 					{
 						"key": "Content-Type",
-						"value": "application/json"
+						"value": "application/vnd.api+json"
 					}
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"quantity\": 1,\n\t\"user_id\": \"d6abe829-c28c-44ec-bee6-3183f2c53fef\"\n}"
+					"raw": "{\n    \"data\": {\n        \"type\": \"purchases\",\n        \"attributes\": {\n            \"quantity\": 1\n        },\n        \"relationships\": {\n            \"user\": {\n                \"data\": {\n                    \"type\": \"users\",\n                    \"id\": \"d6abe829-c28c-44ec-bee6-3183f2c53fef\"\n                }\n            },\n            \"ticket_option\": {\n                \"data\": {\n                    \"type\": \"ticket_options\",\n                    \"id\": \"{{ticketOptionID}}\"\n                }\n            }\n        }\n    }\n}"
 				},
 				"url": {
-					"raw": "localhost:3000/ticket_options/{{ticketOptionID}}/purchases",
+					"raw": "localhost:3000/purchases",
 					"host": [
 						"localhost"
 					],
 					"port": "3000",
 					"path": [
-						"ticket_options",
-						"{{ticketOptionID}}",
 						"purchases"
 					]
 				},
-				"description": "Create Purchase"
+				"description": "Create Purchase with quantity and associated User / Ticket Option relationship"
 			},
 			"response": []
 		}

--- a/Ticket_Allocation.swagger.yaml
+++ b/Ticket_Allocation.swagger.yaml
@@ -1,130 +1,135 @@
-swagger: '2.0'
+openapi: 3.0.3
 info:
-  version: '1.0'
   title: Ticket Allocation
-  description: 'Ticket Allocation Coding Test'
+  version: 1.0.0
   contact: {}
-host: 'localhost:3000'
-basePath: /
-schemes:
-  - http
-consumes:
-  - application/json
-produces:
-  - application/json
+servers:
+  - url: localhost
 paths:
-  '/ticket_options/{ticketOptionID}':
+  /ticket_options/{ticketOptionID}:
     get:
-      description: Get Ticket Option
       summary: Get ticket option
-      tags:
-        - Misc
-      operationId: TicketOptionsByTicketOptionIDGet
-      deprecated: false
-      produces:
-        - application/json
-      parameters:
-        - name: ticketOptionID
-          in: path
-          required: true
-          type: string
-          description: ''
+      description: Get Ticket Option by provided Ticket Option ID
+      operationId: getTicketOption
       responses:
         '200':
           description: ''
-          headers: {}
+    parameters:
+      - name: ticketOptionID
+        in: path
+        required: true
+        schema:
+          type: string
   /ticket_options:
     post:
-      description: Create Ticket Option
       summary: Create ticket option
-      tags:
-        - Misc
-      operationId: TicketOptionsPost
-      deprecated: false
-      produces:
-        - application/json
-      parameters:
-        - name: Content-Type
-          in: header
-          required: true
-          type: string
-          description: ''
-        - name: Body
-          in: body
-          required: true
-          description: ''
-          schema:
-            $ref: '#/definitions/CreateticketoptionRequest'
+      description: Create Ticket Option with given attributes
+      operationId: createTicketOption
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    attributes:
+                      type: object
+                      properties:
+                        allocation:
+                          type: number
+                          example: 100
+                        description:
+                          type: string
+                          example: ticket option description
+                        name:
+                          type: string
+                          example: Test ticket option
+                    type:
+                      type: string
+                      example: ticket_options
+            examples:
+              Create ticket option:
+                value:
+                  data:
+                    attributes:
+                      allocation: 100
+                      description: ticket opion description
+                      name: Test ticket option
+                    type: ticket_options
       responses:
         '200':
           description: ''
-          headers: {}
-  '/ticket_options/{ticketOptionID}/purchases':
+  /purchases:
     post:
-      description: Create Purchase
       summary: Create Purchase
-      tags:
-        - Misc
-      operationId: TicketOptionsPurchasesByTicketOptionIDPost
-      deprecated: false
-      produces:
-        - application/json
-      parameters:
-        - name: Content-Type
-          in: header
-          required: true
-          type: string
-          description: ''
-        - name: Body
-          in: body
-          required: true
-          description: ''
-          schema:
-            $ref: '#/definitions/CreatePurchaseRequest'
-        - name: ticketOptionID
-          in: path
-          required: true
-          type: string
-          description: ''
+      description: >-
+        Create Purchase with quantity and associated User / Ticket Option
+        relationship
+      operationId: createPurchase
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    attributes:
+                      type: object
+                      properties:
+                        quantity:
+                          type: number
+                          example: 1
+                    relationships:
+                      type: object
+                      properties:
+                        ticket_option:
+                          type: object
+                          properties:
+                            data:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                  example: '{{ticketOptionID}}'
+                                type:
+                                  type: string
+                                  example: ticket_options
+                        user:
+                          type: object
+                          properties:
+                            data:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                  example: d6abe829-c28c-44ec-bee6-3183f2c53fef
+                                type:
+                                  type: string
+                                  example: users
+                    type:
+                      type: string
+                      example: purchases
+            examples:
+              Create Purchase:
+                value:
+                  data:
+                    attributes:
+                      quantity: 1
+                    relationships:
+                      ticket_option:
+                        data:
+                          id: '{{ticketOptionID}}'
+                          type: ticket_options
+                      user:
+                        data:
+                          id: d6abe829-c28c-44ec-bee6-3183f2c53fef
+                          type: users
+                    type: purchases
       responses:
         '200':
           description: ''
-          headers: {}
-definitions:
-  CreateticketoptionRequest:
-    title: CreateticketoptionRequest
-    example:
-      name: Test ticket option
-      desc: ticket opion description
-      allocation: 100
-    type: object
-    properties:
-      name:
-        type: string
-      desc:
-        type: string
-      allocation:
-        type: integer
-        format: int32
-    required:
-      - name
-      - desc
-      - allocation
-  CreatePurchaseRequest:
-    title: CreatePurchaseRequest
-    example:
-      quantity: 1
-      user_id: d6abe829-c28c-44ec-bee6-3183f2c53fef
-    type: object
-    properties:
-      quantity:
-        type: integer
-        format: int32
-      user_id:
-        type: string
-    required:
-      - quantity
-      - user_id
-tags:
-  - name: Misc
-    description: ''
+tags: []

--- a/database_structure.sql
+++ b/database_structure.sql
@@ -90,7 +90,7 @@ CREATE TABLE schema_migrations (
 CREATE TABLE ticket_options (
     id uuid DEFAULT uuid_generate_v4() NOT NULL,
     name character varying,
-    "desc" character varying,
+    description character varying,
     allocation integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL


### PR DESCRIPTION
Switching the examples to use jsonapi spec including updating the swagger / postman collection. Swagger was generated from the postman collection with postman2openapi (https://kevinswiber.github.io/postman2openapi/).

Updated the `desc` to `description` as this caused confusion with a previous submission as they assumed that was descending.