### PR TITLE
Updating example database structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Response Body:
 
 ### Purchase from Ticket Option
 
-Purchase a quantity of tickets from the allocation of the given ticket_option:
+Purchase a quantity of tickets from the allocation of the given ticket_option and associate with a user (N.B. managing a user resource is not being looked at here, so an example id should be sufficient):
 
 `POST /purchases`
 

--- a/database_structure.sql
+++ b/database_structure.sql
@@ -2,31 +2,20 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.5
--- Dumped by pg_dump version 9.6.5
+-- Dumped from database version 17.5 (Debian 17.5-1.pgdg120+1)
+-- Dumped by pg_dump version 17.5 (Debian 17.5-1.pgdg120+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
@@ -36,36 +25,22 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
 
 --
--- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: -
+-- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner:
 --
 
 COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
 
 
-SET search_path = public, pg_catalog;
-
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
--- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
+-- Name: purchases; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE ar_internal_metadata (
-    key character varying NOT NULL,
-    value character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: purchases; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE purchases (
-    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+CREATE TABLE public.purchases (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
     quantity integer,
     user_id uuid,
     ticket_option_id uuid,
@@ -74,21 +49,14 @@ CREATE TABLE purchases (
 );
 
 
---
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE schema_migrations (
-    version character varying NOT NULL
-);
-
+ALTER TABLE public.purchases OWNER TO postgres;
 
 --
--- Name: ticket_options; Type: TABLE; Schema: public; Owner: -
+-- Name: ticket_options; Type: TABLE; Schema: public; Owner: postgres
 --
 
-CREATE TABLE ticket_options (
-    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+CREATE TABLE public.ticket_options (
+    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
     name character varying,
     description character varying,
     allocation integer,
@@ -97,57 +65,22 @@ CREATE TABLE ticket_options (
 );
 
 
---
--- Name: tickets; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE tickets (
-    id uuid DEFAULT uuid_generate_v4() NOT NULL,
-    ticket_option_id uuid,
-    purchase_id uuid,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
+ALTER TABLE public.ticket_options OWNER TO postgres;
 
 --
--- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: purchases purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY ar_internal_metadata
-    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
-
-
---
--- Name: purchases purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY purchases
+ALTER TABLE ONLY public.purchases
     ADD CONSTRAINT purchases_pkey PRIMARY KEY (id);
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: ticket_options ticket_options_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
 --
 
-ALTER TABLE ONLY schema_migrations
-    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
-
-
---
--- Name: ticket_options ticket_options_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY ticket_options
+ALTER TABLE ONLY public.ticket_options
     ADD CONSTRAINT ticket_options_pkey PRIMARY KEY (id);
-
-
---
--- Name: tickets tickets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY tickets
-    ADD CONSTRAINT tickets_pkey PRIMARY KEY (id);
 
 
 --


### PR DESCRIPTION
This updates the database structure to be a dump from a newer postgres version (using docker postgres:17). It also strips out some tables that are no longer required, to keep things simpler.

Also a small comment about not needing a user resource has been added to the README after feedback. 